### PR TITLE
Remove YouTube 'related videos' which appear after playback

### DIFF
--- a/templates/video.php
+++ b/templates/video.php
@@ -19,7 +19,7 @@ while ( have_posts() ) : the_post();
 	$ytid = get_post_meta( $post->ID, $key, true );
 
 	if ( is_single() && $ytid != null ) :
-		echo '<div id="int-vid-id-' . $post->ID . '" class="embed-container"><iframe src="https://www.youtube.com/embed/' . $ytid . '"?rel=0 frameborder="0" allowfullscreen></iframe></div>';
+		echo '<div id="int-vid-id-' . $post->ID . '" class="embed-container"><iframe src="https://www.youtube.com/embed/' . $ytid . '?rel=0" frameborder="0" allowfullscreen></iframe></div>';
 
 		echo '<div class="video-script script-id-' . $post->ID . '">' .
 			 the_content() .

--- a/templates/video.php
+++ b/templates/video.php
@@ -19,7 +19,7 @@ while ( have_posts() ) : the_post();
 	$ytid = get_post_meta( $post->ID, $key, true );
 
 	if ( is_single() && $ytid != null ) :
-		echo '<div id="int-vid-id-' . $post->ID . '" class="embed-container"><iframe src="https://www.youtube.com/embed/' . $ytid . '" frameborder="0" allowfullscreen></iframe></div>';
+		echo '<div id="int-vid-id-' . $post->ID . '" class="embed-container"><iframe src="https://www.youtube.com/embed/' . $ytid . '"?rel=0 frameborder="0" allowfullscreen></iframe></div>';
 
 		echo '<div class="video-script script-id-' . $post->ID . '">' .
 			 the_content() .


### PR DESCRIPTION
We don't want the grid of _related videos_ from YouTube to appear after playback is finished for our embedded videos. This change adds the `rel=0` parameter to the `<iframe>` URL to eliminate these related videos.